### PR TITLE
Fix issue #3: remove decorative board markings

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -22,15 +22,14 @@ const tileCount = canvas.width / gridSize;
 const baseTickMs = 140;
 const bestStorageKey = "snake-best-score";
 const boardPalette = {
-    background: "#1b1145",
-    tileA: "#261a63",
-    tileB: "#31207a",
-    squiggle: "rgba(255, 255, 255, 0.08)",
-    sparkle: "rgba(255, 255, 255, 0.14)",
-    food: "#ffe45e",
-    foodAccent: "#ff4fbf",
-    overlay: "rgba(27, 17, 69, 0.8)",
-    overlayText: "#fff8ff",
+    background: "#24115e",
+    tileA: "#33207d",
+    tileB: "#442b96",
+    gridGlow: "rgba(255, 255, 255, 0.08)",
+    food: "#fff07a",
+    foodAccent: "#ff5fb2",
+    overlay: "rgba(36, 17, 94, 0.76)",
+    overlayText: "#fffdfd",
 };
 const snakePalette = ["#3cf2ff", "#7c5cff", "#ff4fbf", "#ff8a3d", "#ffe45e", "#57f287"];
 let snake = [];
@@ -167,32 +166,18 @@ function drawSavedByTheBellBackdrop() {
         }
     }
     ctx.save();
-    ctx.strokeStyle = boardPalette.squiggle;
-    ctx.lineWidth = 4;
-    ctx.lineCap = "round";
-    const squiggles = [
-        [24, 82, 92, 48, 148, 92, 212, 56],
-        [288, 40, 334, 80, 390, 28, 442, 66],
-        [42, 372, 110, 326, 156, 394, 228, 340],
-        [272, 398, 328, 350, 388, 420, 444, 374],
-    ];
-    for (const [startX, startY, cp1X, cp1Y, cp2X, cp2Y, endX, endY] of squiggles) {
+    ctx.strokeStyle = boardPalette.gridGlow;
+    ctx.lineWidth = 1;
+    for (let line = 0; line <= tileCount; line += 1) {
+        const offset = line * gridSize;
         ctx.beginPath();
-        ctx.moveTo(startX, startY);
-        ctx.bezierCurveTo(cp1X, cp1Y, cp2X, cp2Y, endX, endY);
+        ctx.moveTo(offset, 0);
+        ctx.lineTo(offset, canvas.height);
         ctx.stroke();
-    }
-    ctx.fillStyle = boardPalette.sparkle;
-    const sparkles = [
-        { x: 84, y: 150, size: 10 },
-        { x: 398, y: 126, size: 8 },
-        { x: 340, y: 292, size: 10 },
-        { x: 130, y: 434, size: 7 },
-    ];
-    for (const sparkle of sparkles) {
         ctx.beginPath();
-        ctx.arc(sparkle.x, sparkle.y, sparkle.size, 0, Math.PI * 2);
-        ctx.fill();
+        ctx.moveTo(0, offset);
+        ctx.lineTo(canvas.width, offset);
+        ctx.stroke();
     }
     ctx.restore();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,15 +28,14 @@ const tileCount = canvas.width / gridSize;
 const baseTickMs = 140;
 const bestStorageKey = "snake-best-score";
 const boardPalette = {
-  background: "#1b1145",
-  tileA: "#261a63",
-  tileB: "#31207a",
-  squiggle: "rgba(255, 255, 255, 0.08)",
-  sparkle: "rgba(255, 255, 255, 0.14)",
-  food: "#ffe45e",
-  foodAccent: "#ff4fbf",
-  overlay: "rgba(27, 17, 69, 0.8)",
-  overlayText: "#fff8ff",
+  background: "#24115e",
+  tileA: "#33207d",
+  tileB: "#442b96",
+  gridGlow: "rgba(255, 255, 255, 0.08)",
+  food: "#fff07a",
+  foodAccent: "#ff5fb2",
+  overlay: "rgba(36, 17, 94, 0.76)",
+  overlayText: "#fffdfd",
 };
 const snakePalette = ["#3cf2ff", "#7c5cff", "#ff4fbf", "#ff8a3d", "#ffe45e", "#57f287"];
 
@@ -200,36 +199,21 @@ function drawSavedByTheBellBackdrop(): void {
   }
 
   ctx.save();
-  ctx.strokeStyle = boardPalette.squiggle;
-  ctx.lineWidth = 4;
-  ctx.lineCap = "round";
+  ctx.strokeStyle = boardPalette.gridGlow;
+  ctx.lineWidth = 1;
 
-  const squiggles = [
-    [24, 82, 92, 48, 148, 92, 212, 56],
-    [288, 40, 334, 80, 390, 28, 442, 66],
-    [42, 372, 110, 326, 156, 394, 228, 340],
-    [272, 398, 328, 350, 388, 420, 444, 374],
-  ];
+  for (let line = 0; line <= tileCount; line += 1) {
+    const offset = line * gridSize;
 
-  for (const [startX, startY, cp1X, cp1Y, cp2X, cp2Y, endX, endY] of squiggles) {
     ctx.beginPath();
-    ctx.moveTo(startX, startY);
-    ctx.bezierCurveTo(cp1X, cp1Y, cp2X, cp2Y, endX, endY);
+    ctx.moveTo(offset, 0);
+    ctx.lineTo(offset, canvas.height);
     ctx.stroke();
-  }
 
-  ctx.fillStyle = boardPalette.sparkle;
-  const sparkles = [
-    { x: 84, y: 150, size: 10 },
-    { x: 398, y: 126, size: 8 },
-    { x: 340, y: 292, size: 10 },
-    { x: 130, y: 434, size: 7 },
-  ];
-
-  for (const sparkle of sparkles) {
     ctx.beginPath();
-    ctx.arc(sparkle.x, sparkle.y, sparkle.size, 0, Math.PI * 2);
-    ctx.fill();
+    ctx.moveTo(0, offset);
+    ctx.lineTo(canvas.width, offset);
+    ctx.stroke();
   }
 
   ctx.restore();

--- a/src/style.css
+++ b/src/style.css
@@ -1,8 +1,8 @@
 :root {
   color-scheme: dark;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-  background: #16092f;
-  color: #fff8ff;
+  background: #24115e;
+  color: #fffdfd;
 }
 
 * {
@@ -18,10 +18,10 @@ body {
 body {
   min-height: 100vh;
   background:
-    radial-gradient(circle at 20% 15%, rgba(60, 242, 255, 0.26), transparent 28%),
-    radial-gradient(circle at 82% 18%, rgba(255, 79, 191, 0.28), transparent 24%),
-    radial-gradient(circle at 68% 78%, rgba(255, 228, 94, 0.18), transparent 26%),
-    linear-gradient(135deg, #16092f 0%, #261a63 45%, #1b1145 100%);
+    radial-gradient(circle at 20% 15%, rgba(60, 242, 255, 0.34), transparent 30%),
+    radial-gradient(circle at 82% 18%, rgba(255, 95, 178, 0.3), transparent 26%),
+    radial-gradient(circle at 68% 78%, rgba(255, 240, 122, 0.24), transparent 28%),
+    linear-gradient(135deg, #24115e 0%, #4b2db2 48%, #34207d 100%);
 }
 
 .app {
@@ -39,11 +39,11 @@ body {
   grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
   gap: 24px;
   align-items: stretch;
-  background: linear-gradient(180deg, rgba(41, 19, 87, 0.92), rgba(22, 9, 47, 0.9));
-  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: linear-gradient(180deg, rgba(77, 45, 178, 0.92), rgba(36, 17, 94, 0.9));
+  border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 28px;
   padding: 28px;
-  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.4), 0 0 0 2px rgba(255, 79, 191, 0.12);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.32), 0 0 0 2px rgba(255, 95, 178, 0.14);
   backdrop-filter: blur(14px);
 }
 
@@ -65,8 +65,8 @@ h1 {
   font-size: clamp(2.5rem, 5vw, 4.2rem);
   line-height: 0.95;
   letter-spacing: -0.05em;
-  color: #fff8ff;
-  text-shadow: 0 0 18px rgba(255, 79, 191, 0.28);
+  color: #fffdfd;
+  text-shadow: 0 0 18px rgba(255, 95, 178, 0.24);
 }
 
 .subtitle {
@@ -144,9 +144,9 @@ canvas {
   display: block;
   margin: 0 auto;
   border-radius: 28px;
-  background: #1b1145;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.35), 0 0 28px rgba(60, 242, 255, 0.18);
+  background: #24115e;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.3), 0 0 28px rgba(60, 242, 255, 0.22);
   touch-action: none;
 }
 


### PR DESCRIPTION
## Summary
- remove the decorative dots and bracket-like markings painted into the game board
- replace them with a subtle clean grid so the board stays readable
- brighten the overall neon palette to make the theme feel more fun

Closes #3