### PR TITLE
Surface mobile haptics support in the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A small browser-based Snake game written in TypeScript.
 
 - Arrow keys or WASD controls
 - Mobile-friendly compact touch controls
+- Haptic feedback on supported mobile browsers, with an in-game status note when unavailable
 - Optional wrap-around walls mode
 - Persistent best score via localStorage
 - Increasing speed as you eat food

--- a/dist/main.js
+++ b/dist/main.js
@@ -10,6 +10,7 @@ const canvas = requireElement("#game");
 const scoreEl = requireElement("#score");
 const bestEl = requireElement("#best");
 const speedEl = requireElement("#speed");
+const hapticsStatusEl = requireElement("#haptics-status");
 const wrapToggleEl = requireElement("#wrap-toggle");
 const restartButtonEl = requireElement("#restart-button");
 const touchButtons = Array.from(document.querySelectorAll("[data-dir]"));
@@ -38,6 +39,8 @@ const vibrationPatterns = {
     food: 18,
     gameOver: [24, 18, 32],
 };
+const isTouchCapable = (typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches) ||
+    (typeof navigator !== "undefined" && navigator.maxTouchPoints > 0);
 let snake = [];
 let direction = { x: 1, y: 0 };
 let nextDirection = { x: 1, y: 0 };
@@ -48,6 +51,7 @@ let gameOver = false;
 let wrapWalls = false;
 let lastTick = 0;
 let shakeTimeout = null;
+let hapticsSupport = "unknown";
 bestEl.textContent = String(best);
 function setWrapToggleUi() {
     wrapToggleEl.textContent = `Wrap: ${wrapWalls ? "On" : "Off"}`;
@@ -121,15 +125,32 @@ function triggerShake() {
         shakeTimeout = null;
     }, 180);
 }
+function setHapticsStatus(next) {
+    hapticsSupport = next;
+    const supportedAttribute = next === "unknown" ? "maybe" : String(next === "supported");
+    hapticsStatusEl.dataset.supported = supportedAttribute;
+    if (!isTouchCapable) {
+        hapticsStatusEl.textContent = "Haptics: Mostly relevant on phones and tablets.";
+        return;
+    }
+    if (next === "supported") {
+        hapticsStatusEl.textContent = "Haptics: Ready on this device/browser.";
+        return;
+    }
+    if (next === "unsupported") {
+        hapticsStatusEl.textContent = "Haptics: Not available here — gameplay still works without vibration.";
+        return;
+    }
+    hapticsStatusEl.textContent = "Haptics: This browser may ignore vibration unless the device/browser supports it.";
+}
 function triggerHaptic(pattern) {
     if (typeof navigator === "undefined" || typeof navigator.vibrate !== "function") {
-        return;
+        setHapticsStatus("unsupported");
+        return false;
     }
-    if (typeof pattern === "number") {
-        navigator.vibrate(pattern);
-        return;
-    }
-    navigator.vibrate(Array.from(pattern));
+    const didVibrate = typeof pattern === "number" ? navigator.vibrate(pattern) : navigator.vibrate(Array.from(pattern));
+    setHapticsStatus(didVibrate ? "supported" : "unsupported");
+    return didVibrate;
 }
 function step() {
     if (gameOver) {
@@ -286,6 +307,7 @@ for (const button of touchButtons) {
     });
 }
 setWrapToggleUi();
+setHapticsStatus(typeof navigator !== "undefined" && typeof navigator.vibrate === "function" ? "unknown" : "unsupported");
 resetGame();
 render();
 requestAnimationFrame(loop);

--- a/index.html
+++ b/index.html
@@ -24,6 +24,10 @@
             <div><span>Speed</span><strong id="speed">1x</strong></div>
           </div>
 
+          <div class="status-stack" aria-live="polite">
+            <p id="haptics-status" class="status-pill">Haptics: Checking device support…</p>
+          </div>
+
           <div class="controls">
             <p>Use arrow keys or WASD to move. Press space to restart after game over, or tap Restart on mobile.</p>
           </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ const canvas = requireElement<HTMLCanvasElement>("#game");
 const scoreEl = requireElement<HTMLElement>("#score");
 const bestEl = requireElement<HTMLElement>("#best");
 const speedEl = requireElement<HTMLElement>("#speed");
+const hapticsStatusEl = requireElement<HTMLElement>("#haptics-status");
 const wrapToggleEl = requireElement<HTMLButtonElement>("#wrap-toggle");
 const restartButtonEl = requireElement<HTMLButtonElement>("#restart-button");
 const touchButtons = Array.from(document.querySelectorAll<HTMLButtonElement>("[data-dir]"));
@@ -44,6 +45,11 @@ const vibrationPatterns = {
   food: 18,
   gameOver: [24, 18, 32],
 } as const;
+const isTouchCapable =
+  (typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches) ||
+  (typeof navigator !== "undefined" && navigator.maxTouchPoints > 0);
+
+type HapticsSupport = "supported" | "unsupported" | "unknown";
 
 let snake: Point[] = [];
 let direction: Direction = { x: 1, y: 0 };
@@ -55,6 +61,7 @@ let gameOver = false;
 let wrapWalls = false;
 let lastTick = 0;
 let shakeTimeout: number | null = null;
+let hapticsSupport: HapticsSupport = "unknown";
 
 bestEl.textContent = String(best);
 
@@ -144,17 +151,40 @@ function triggerShake(): void {
   }, 180);
 }
 
-function triggerHaptic(pattern: number | readonly number[]): void {
+function setHapticsStatus(next: HapticsSupport): void {
+  hapticsSupport = next;
+
+  const supportedAttribute = next === "unknown" ? "maybe" : String(next === "supported");
+  hapticsStatusEl.dataset.supported = supportedAttribute;
+
+  if (!isTouchCapable) {
+    hapticsStatusEl.textContent = "Haptics: Mostly relevant on phones and tablets.";
+    return;
+  }
+
+  if (next === "supported") {
+    hapticsStatusEl.textContent = "Haptics: Ready on this device/browser.";
+    return;
+  }
+
+  if (next === "unsupported") {
+    hapticsStatusEl.textContent = "Haptics: Not available here — gameplay still works without vibration.";
+    return;
+  }
+
+  hapticsStatusEl.textContent = "Haptics: This browser may ignore vibration unless the device/browser supports it.";
+}
+
+function triggerHaptic(pattern: number | readonly number[]): boolean {
   if (typeof navigator === "undefined" || typeof navigator.vibrate !== "function") {
-    return;
+    setHapticsStatus("unsupported");
+    return false;
   }
 
-  if (typeof pattern === "number") {
-    navigator.vibrate(pattern);
-    return;
-  }
+  const didVibrate = typeof pattern === "number" ? navigator.vibrate(pattern) : navigator.vibrate(Array.from(pattern));
 
-  navigator.vibrate(Array.from(pattern));
+  setHapticsStatus(didVibrate ? "supported" : "unsupported");
+  return didVibrate;
 }
 
 function step(): void {
@@ -342,6 +372,7 @@ for (const button of touchButtons) {
 }
 
 setWrapToggleUi();
+setHapticsStatus(typeof navigator !== "undefined" && typeof navigator.vibrate === "function" ? "unknown" : "unsupported");
 resetGame();
 render();
 requestAnimationFrame(loop);

--- a/src/style.css
+++ b/src/style.css
@@ -192,6 +192,35 @@ canvas.shake {
   100% { transform: translate(0, 0); }
 }
 
+.status-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.status-pill {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  color: #fff8ff;
+  font-size: 0.92rem;
+  line-height: 1.35;
+}
+
+.status-pill[data-supported="true"] {
+  background: rgba(87, 242, 135, 0.14);
+  border-color: rgba(87, 242, 135, 0.3);
+  color: #dffff0;
+}
+
+.status-pill[data-supported="false"] {
+  background: rgba(255, 138, 61, 0.14);
+  border-color: rgba(255, 138, 61, 0.3);
+  color: #ffe7d6;
+}
+
 .controls {
   color: #f8d8ff;
   line-height: 1.6;


### PR DESCRIPTION
## Summary
- add an in-game haptics status pill so mobile users can tell whether vibration is available
- update haptics handling to use the boolean result of `navigator.vibrate()` instead of failing silently
- document that unsupported browsers should degrade cleanly without vibration

## Notes
- browser support for the Vibration API is inconsistent across mobile browsers, so the UI now makes that visible instead of leaving users guessing

## Testing
- npm run build