### PR TITLE
Clarify iOS web haptics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A small browser-based Snake game written in TypeScript.
 
 - Arrow keys or WASD controls
 - Mobile-friendly compact touch controls
-- Haptic feedback on supported mobile browsers, with an in-game status note when unavailable
+- Haptic feedback on supported mobile browsers, with clearer in-game messaging when iPhone/iPad web haptics are limited or unavailable
 - Optional wrap-around walls mode
 - Persistent best score via localStorage
 - Increasing speed as you eat food

--- a/dist/main.js
+++ b/dist/main.js
@@ -41,6 +41,11 @@ const vibrationPatterns = {
 };
 const isTouchCapable = (typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches) ||
     (typeof navigator !== "undefined" && navigator.maxTouchPoints > 0);
+const userAgent = typeof navigator === "undefined" ? "" : navigator.userAgent;
+const isAppleMobileDevice = /iPhone|iPad|iPod/i.test(userAgent) ||
+    (typeof navigator !== "undefined" && navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+const isStandaloneDisplayMode = (typeof window !== "undefined" && window.matchMedia("(display-mode: standalone)").matches) ||
+    (typeof navigator !== "undefined" && "standalone" in navigator && Boolean(navigator.standalone));
 let snake = [];
 let direction = { x: 1, y: 0 };
 let nextDirection = { x: 1, y: 0 };
@@ -127,7 +132,7 @@ function triggerShake() {
 }
 function setHapticsStatus(next) {
     hapticsSupport = next;
-    const supportedAttribute = next === "unknown" ? "maybe" : String(next === "supported");
+    const supportedAttribute = next === "supported" ? "true" : next === "unsupported" ? "false" : "maybe";
     hapticsStatusEl.dataset.supported = supportedAttribute;
     if (!isTouchCapable) {
         hapticsStatusEl.textContent = "Haptics: Mostly relevant on phones and tablets.";
@@ -135,6 +140,12 @@ function setHapticsStatus(next) {
     }
     if (next === "supported") {
         hapticsStatusEl.textContent = "Haptics: Ready on this device/browser.";
+        return;
+    }
+    if (next === "limited") {
+        hapticsStatusEl.textContent = isStandaloneDisplayMode
+            ? "Haptics: iPhone/iPad home screen apps still have limited vibration support, so this install may stay silent."
+            : "Haptics: iPhone/iPad browsers still expose vibration inconsistently, so this device may stay silent.";
         return;
     }
     if (next === "unsupported") {
@@ -145,11 +156,11 @@ function setHapticsStatus(next) {
 }
 function triggerHaptic(pattern) {
     if (typeof navigator === "undefined" || typeof navigator.vibrate !== "function") {
-        setHapticsStatus("unsupported");
+        setHapticsStatus(isAppleMobileDevice ? "limited" : "unsupported");
         return false;
     }
     const didVibrate = typeof pattern === "number" ? navigator.vibrate(pattern) : navigator.vibrate(Array.from(pattern));
-    setHapticsStatus(didVibrate ? "supported" : "unsupported");
+    setHapticsStatus(didVibrate ? "supported" : isAppleMobileDevice ? "limited" : "unsupported");
     return didVibrate;
 }
 function step() {
@@ -307,7 +318,11 @@ for (const button of touchButtons) {
     });
 }
 setWrapToggleUi();
-setHapticsStatus(typeof navigator !== "undefined" && typeof navigator.vibrate === "function" ? "unknown" : "unsupported");
+setHapticsStatus(typeof navigator !== "undefined" && typeof navigator.vibrate === "function"
+    ? "unknown"
+    : isAppleMobileDevice
+        ? "limited"
+        : "unsupported");
 resetGame();
 render();
 requestAnimationFrame(loop);

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,8 +48,14 @@ const vibrationPatterns = {
 const isTouchCapable =
   (typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches) ||
   (typeof navigator !== "undefined" && navigator.maxTouchPoints > 0);
+const userAgent = typeof navigator === "undefined" ? "" : navigator.userAgent;
+const isAppleMobileDevice = /iPhone|iPad|iPod/i.test(userAgent) ||
+  (typeof navigator !== "undefined" && navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+const isStandaloneDisplayMode =
+  (typeof window !== "undefined" && window.matchMedia("(display-mode: standalone)").matches) ||
+  (typeof navigator !== "undefined" && "standalone" in navigator && Boolean((navigator as Navigator & { standalone?: boolean }).standalone));
 
-type HapticsSupport = "supported" | "unsupported" | "unknown";
+type HapticsSupport = "supported" | "limited" | "unsupported" | "unknown";
 
 let snake: Point[] = [];
 let direction: Direction = { x: 1, y: 0 };
@@ -154,7 +160,7 @@ function triggerShake(): void {
 function setHapticsStatus(next: HapticsSupport): void {
   hapticsSupport = next;
 
-  const supportedAttribute = next === "unknown" ? "maybe" : String(next === "supported");
+  const supportedAttribute = next === "supported" ? "true" : next === "unsupported" ? "false" : "maybe";
   hapticsStatusEl.dataset.supported = supportedAttribute;
 
   if (!isTouchCapable) {
@@ -164,6 +170,13 @@ function setHapticsStatus(next: HapticsSupport): void {
 
   if (next === "supported") {
     hapticsStatusEl.textContent = "Haptics: Ready on this device/browser.";
+    return;
+  }
+
+  if (next === "limited") {
+    hapticsStatusEl.textContent = isStandaloneDisplayMode
+      ? "Haptics: iPhone/iPad home screen apps still have limited vibration support, so this install may stay silent."
+      : "Haptics: iPhone/iPad browsers still expose vibration inconsistently, so this device may stay silent.";
     return;
   }
 
@@ -177,13 +190,13 @@ function setHapticsStatus(next: HapticsSupport): void {
 
 function triggerHaptic(pattern: number | readonly number[]): boolean {
   if (typeof navigator === "undefined" || typeof navigator.vibrate !== "function") {
-    setHapticsStatus("unsupported");
+    setHapticsStatus(isAppleMobileDevice ? "limited" : "unsupported");
     return false;
   }
 
   const didVibrate = typeof pattern === "number" ? navigator.vibrate(pattern) : navigator.vibrate(Array.from(pattern));
 
-  setHapticsStatus(didVibrate ? "supported" : "unsupported");
+  setHapticsStatus(didVibrate ? "supported" : isAppleMobileDevice ? "limited" : "unsupported");
   return didVibrate;
 }
 
@@ -372,7 +385,13 @@ for (const button of touchButtons) {
 }
 
 setWrapToggleUi();
-setHapticsStatus(typeof navigator !== "undefined" && typeof navigator.vibrate === "function" ? "unknown" : "unsupported");
+setHapticsStatus(
+  typeof navigator !== "undefined" && typeof navigator.vibrate === "function"
+    ? "unknown"
+    : isAppleMobileDevice
+      ? "limited"
+      : "unsupported",
+);
 resetGame();
 render();
 requestAnimationFrame(loop);


### PR DESCRIPTION
## Summary
- detect Apple mobile browsers/home-screen installs separately from generic unsupported devices
- show a limited-support status message when iPhone/iPad web haptics are inconsistent or unavailable
- keep supported browsers reporting ready once navigator.vibrate() succeeds

## Testing
- npm run build