### PR TITLE
Add installable PWA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,18 @@ A small browser-based Snake game written in TypeScript.
 
 - Arrow keys or WASD controls
 - Mobile-friendly compact touch controls
-- Haptic feedback on supported mobile browsers, with an in-game status note when unavailable
+- Installable PWA with offline support for the core app shell
+- Haptic feedback on supported mobile browsers, with clearer in-game messaging when iPhone/iPad PWAs still lack native Taptic Engine access
 - Optional wrap-around walls mode
 - Persistent best score via localStorage
 - Increasing speed as you eat food
+
+## Install it
+
+- **Desktop Chromium browsers:** use the install button in the address bar.
+- **iPhone/iPad Safari:** use **Share → Add to Home Screen**.
+- **Offline:** once loaded, the app shell is cached so the game can start without a network connection.
+- **Haptics on Apple devices:** installing as a PWA does not unlock native iOS haptics by itself. Full Taptic Engine support still requires a native wrapper such as Capacitor.
 
 ## Run it locally
 

--- a/dist/main.js
+++ b/dist/main.js
@@ -11,6 +11,7 @@ const scoreEl = requireElement("#score");
 const bestEl = requireElement("#best");
 const speedEl = requireElement("#speed");
 const hapticsStatusEl = requireElement("#haptics-status");
+const installStatusEl = requireElement("#install-status");
 const wrapToggleEl = requireElement("#wrap-toggle");
 const restartButtonEl = requireElement("#restart-button");
 const touchButtons = Array.from(document.querySelectorAll("[data-dir]"));
@@ -41,6 +42,11 @@ const vibrationPatterns = {
 };
 const isTouchCapable = (typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches) ||
     (typeof navigator !== "undefined" && navigator.maxTouchPoints > 0);
+const userAgent = typeof navigator === "undefined" ? "" : navigator.userAgent;
+const isAppleMobileDevice = /iPhone|iPad|iPod/i.test(userAgent) ||
+    (typeof navigator !== "undefined" && navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+const isStandaloneDisplayMode = (typeof window !== "undefined" && window.matchMedia("(display-mode: standalone)").matches) ||
+    (typeof navigator !== "undefined" && "standalone" in navigator && Boolean(navigator.standalone));
 let snake = [];
 let direction = { x: 1, y: 0 };
 let nextDirection = { x: 1, y: 0 };
@@ -127,14 +133,22 @@ function triggerShake() {
 }
 function setHapticsStatus(next) {
     hapticsSupport = next;
-    const supportedAttribute = next === "unknown" ? "maybe" : String(next === "supported");
+    const supportedAttribute = next === "supported" ? "true" : next === "unsupported" ? "false" : "maybe";
     hapticsStatusEl.dataset.supported = supportedAttribute;
     if (!isTouchCapable) {
         hapticsStatusEl.textContent = "Haptics: Mostly relevant on phones and tablets.";
         return;
     }
     if (next === "supported") {
-        hapticsStatusEl.textContent = "Haptics: Ready on this device/browser.";
+        hapticsStatusEl.textContent = isStandaloneDisplayMode
+            ? "Haptics: This installed app can use browser vibration support when the device exposes it."
+            : "Haptics: Ready on this device/browser.";
+        return;
+    }
+    if (next === "limited") {
+        hapticsStatusEl.textContent = isStandaloneDisplayMode
+            ? "Haptics: Installed iPhone/iPad PWAs still do not get native Taptic Engine APIs, so vibration may stay silent unless the game is wrapped natively."
+            : "Haptics: iPhone/iPad browsers still expose vibration inconsistently, so this device may stay silent.";
         return;
     }
     if (next === "unsupported") {
@@ -143,13 +157,25 @@ function setHapticsStatus(next) {
     }
     hapticsStatusEl.textContent = "Haptics: This browser may ignore vibration unless the device/browser supports it.";
 }
+function setInstallStatus() {
+    if (isStandaloneDisplayMode) {
+        installStatusEl.dataset.supported = "true";
+        installStatusEl.textContent = "Install: Running as an installed app.";
+        return;
+    }
+    const canInstall = typeof window !== "undefined" && "serviceWorker" in navigator;
+    installStatusEl.dataset.supported = canInstall ? "maybe" : "false";
+    installStatusEl.textContent = canInstall
+        ? "Install: Browser should offer Add to Home Screen or install once the page finishes loading."
+        : "Install: This browser does not expose the usual install hooks.";
+}
 function triggerHaptic(pattern) {
     if (typeof navigator === "undefined" || typeof navigator.vibrate !== "function") {
-        setHapticsStatus("unsupported");
+        setHapticsStatus(isAppleMobileDevice ? "limited" : "unsupported");
         return false;
     }
     const didVibrate = typeof pattern === "number" ? navigator.vibrate(pattern) : navigator.vibrate(Array.from(pattern));
-    setHapticsStatus(didVibrate ? "supported" : "unsupported");
+    setHapticsStatus(didVibrate ? "supported" : isAppleMobileDevice ? "limited" : "unsupported");
     return didVibrate;
 }
 function step() {
@@ -306,8 +332,22 @@ for (const button of touchButtons) {
         }
     });
 }
+function registerServiceWorker() {
+    if (typeof window === "undefined" || !("serviceWorker" in navigator)) {
+        return;
+    }
+    window.addEventListener("load", () => {
+        void navigator.serviceWorker.register("./sw.js");
+    }, { once: true });
+}
 setWrapToggleUi();
-setHapticsStatus(typeof navigator !== "undefined" && typeof navigator.vibrate === "function" ? "unknown" : "unsupported");
+setInstallStatus();
+setHapticsStatus(typeof navigator !== "undefined" && typeof navigator.vibrate === "function"
+    ? "unknown"
+    : isAppleMobileDevice
+        ? "limited"
+        : "unsupported");
+registerServiceWorker();
 resetGame();
 render();
 requestAnimationFrame(loop);

--- a/icons/icon-192.svg
+++ b/icons/icon-192.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" role="img" aria-label="Snake app icon">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#24115e" />
+      <stop offset="55%" stop-color="#4b2db2" />
+      <stop offset="100%" stop-color="#34207d" />
+    </linearGradient>
+    <linearGradient id="snake" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3cf2ff" />
+      <stop offset="50%" stop-color="#7c5cff" />
+      <stop offset="100%" stop-color="#ff4fbf" />
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="42" fill="url(#bg)" />
+  <rect x="30" y="30" width="132" height="132" rx="28" fill="none" stroke="rgba(255,255,255,0.18)" stroke-width="6" />
+  <path d="M53 122c0-15 12-27 27-27h32c10 0 18-8 18-18s-8-18-18-18H72" fill="none" stroke="url(#snake)" stroke-linecap="round" stroke-linejoin="round" stroke-width="20" />
+  <circle cx="135" cy="77" r="16" fill="#fffdfd" />
+  <circle cx="141" cy="72" r="4" fill="#24115e" />
+  <circle cx="76" cy="74" r="11" fill="#ffe45e" />
+  <circle cx="76" cy="74" r="5" fill="#ff5fb2" />
+</svg>

--- a/icons/icon-512.svg
+++ b/icons/icon-512.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Snake app icon">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#24115e" />
+      <stop offset="55%" stop-color="#4b2db2" />
+      <stop offset="100%" stop-color="#34207d" />
+    </linearGradient>
+    <linearGradient id="snake" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3cf2ff" />
+      <stop offset="50%" stop-color="#7c5cff" />
+      <stop offset="100%" stop-color="#ff4fbf" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="url(#bg)" />
+  <rect x="80" y="80" width="352" height="352" rx="76" fill="none" stroke="rgba(255,255,255,0.18)" stroke-width="16" />
+  <path d="M140 326c0-40 32-72 72-72h86c25 0 48-20 48-48s-23-48-48-48H188" fill="none" stroke="url(#snake)" stroke-linecap="round" stroke-linejoin="round" stroke-width="52" />
+  <circle cx="358" cy="206" r="42" fill="#fffdfd" />
+  <circle cx="372" cy="192" r="11" fill="#24115e" />
+  <circle cx="208" cy="198" r="28" fill="#ffe45e" />
+  <circle cx="208" cy="198" r="13" fill="#ff5fb2" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#24115e" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Snake" />
     <title>Snake</title>
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="icon" href="./icons/icon-192.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="./icons/icon-192.svg" />
     <link rel="stylesheet" href="./src/style.css" />
   </head>
   <body>
@@ -25,6 +32,7 @@
           </div>
 
           <div class="status-stack" aria-live="polite">
+            <p id="install-status" class="status-pill">Install: Checking browser support…</p>
             <p id="haptics-status" class="status-pill">Haptics: Checking device support…</p>
           </div>
 

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,25 @@
+{
+  "name": "Snake",
+  "short_name": "Snake",
+  "description": "A neon TypeScript Snake game you can install and play offline.",
+  "start_url": ".",
+  "scope": ".",
+  "display": "standalone",
+  "background_color": "#24115e",
+  "theme_color": "#24115e",
+  "orientation": "portrait",
+  "icons": [
+    {
+      "src": "./icons/icon-192.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "./icons/icon-512.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ const scoreEl = requireElement<HTMLElement>("#score");
 const bestEl = requireElement<HTMLElement>("#best");
 const speedEl = requireElement<HTMLElement>("#speed");
 const hapticsStatusEl = requireElement<HTMLElement>("#haptics-status");
+const installStatusEl = requireElement<HTMLElement>("#install-status");
 const wrapToggleEl = requireElement<HTMLButtonElement>("#wrap-toggle");
 const restartButtonEl = requireElement<HTMLButtonElement>("#restart-button");
 const touchButtons = Array.from(document.querySelectorAll<HTMLButtonElement>("[data-dir]"));
@@ -48,8 +49,14 @@ const vibrationPatterns = {
 const isTouchCapable =
   (typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches) ||
   (typeof navigator !== "undefined" && navigator.maxTouchPoints > 0);
+const userAgent = typeof navigator === "undefined" ? "" : navigator.userAgent;
+const isAppleMobileDevice = /iPhone|iPad|iPod/i.test(userAgent) ||
+  (typeof navigator !== "undefined" && navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+const isStandaloneDisplayMode =
+  (typeof window !== "undefined" && window.matchMedia("(display-mode: standalone)").matches) ||
+  (typeof navigator !== "undefined" && "standalone" in navigator && Boolean((navigator as Navigator & { standalone?: boolean }).standalone));
 
-type HapticsSupport = "supported" | "unsupported" | "unknown";
+type HapticsSupport = "supported" | "limited" | "unsupported" | "unknown";
 
 let snake: Point[] = [];
 let direction: Direction = { x: 1, y: 0 };
@@ -154,7 +161,7 @@ function triggerShake(): void {
 function setHapticsStatus(next: HapticsSupport): void {
   hapticsSupport = next;
 
-  const supportedAttribute = next === "unknown" ? "maybe" : String(next === "supported");
+  const supportedAttribute = next === "supported" ? "true" : next === "unsupported" ? "false" : "maybe";
   hapticsStatusEl.dataset.supported = supportedAttribute;
 
   if (!isTouchCapable) {
@@ -163,7 +170,16 @@ function setHapticsStatus(next: HapticsSupport): void {
   }
 
   if (next === "supported") {
-    hapticsStatusEl.textContent = "Haptics: Ready on this device/browser.";
+    hapticsStatusEl.textContent = isStandaloneDisplayMode
+      ? "Haptics: This installed app can use browser vibration support when the device exposes it."
+      : "Haptics: Ready on this device/browser.";
+    return;
+  }
+
+  if (next === "limited") {
+    hapticsStatusEl.textContent = isStandaloneDisplayMode
+      ? "Haptics: Installed iPhone/iPad PWAs still do not get native Taptic Engine APIs, so vibration may stay silent unless the game is wrapped natively."
+      : "Haptics: iPhone/iPad browsers still expose vibration inconsistently, so this device may stay silent.";
     return;
   }
 
@@ -175,15 +191,29 @@ function setHapticsStatus(next: HapticsSupport): void {
   hapticsStatusEl.textContent = "Haptics: This browser may ignore vibration unless the device/browser supports it.";
 }
 
+function setInstallStatus(): void {
+  if (isStandaloneDisplayMode) {
+    installStatusEl.dataset.supported = "true";
+    installStatusEl.textContent = "Install: Running as an installed app.";
+    return;
+  }
+
+  const canInstall = typeof window !== "undefined" && "serviceWorker" in navigator;
+  installStatusEl.dataset.supported = canInstall ? "maybe" : "false";
+  installStatusEl.textContent = canInstall
+    ? "Install: Browser should offer Add to Home Screen or install once the page finishes loading."
+    : "Install: This browser does not expose the usual install hooks.";
+}
+
 function triggerHaptic(pattern: number | readonly number[]): boolean {
   if (typeof navigator === "undefined" || typeof navigator.vibrate !== "function") {
-    setHapticsStatus("unsupported");
+    setHapticsStatus(isAppleMobileDevice ? "limited" : "unsupported");
     return false;
   }
 
   const didVibrate = typeof pattern === "number" ? navigator.vibrate(pattern) : navigator.vibrate(Array.from(pattern));
 
-  setHapticsStatus(didVibrate ? "supported" : "unsupported");
+  setHapticsStatus(didVibrate ? "supported" : isAppleMobileDevice ? "limited" : "unsupported");
   return didVibrate;
 }
 
@@ -371,8 +401,26 @@ for (const button of touchButtons) {
   });
 }
 
+function registerServiceWorker(): void {
+  if (typeof window === "undefined" || !("serviceWorker" in navigator)) {
+    return;
+  }
+
+  window.addEventListener("load", () => {
+    void navigator.serviceWorker.register("./sw.js");
+  }, { once: true });
+}
+
 setWrapToggleUi();
-setHapticsStatus(typeof navigator !== "undefined" && typeof navigator.vibrate === "function" ? "unknown" : "unsupported");
+setInstallStatus();
+setHapticsStatus(
+  typeof navigator !== "undefined" && typeof navigator.vibrate === "function"
+    ? "unknown"
+    : isAppleMobileDevice
+      ? "limited"
+      : "unsupported",
+);
+registerServiceWorker();
 resetGame();
 render();
 requestAnimationFrame(loop);

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,46 @@
+const CACHE_NAME = "snake-pwa-v1";
+const ASSETS = [
+  "./",
+  "./index.html",
+  "./manifest.webmanifest",
+  "./src/style.css",
+  "./dist/main.js",
+  "./icons/icon-192.svg",
+  "./icons/icon-512.svg"
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)),
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(
+      keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)),
+    )),
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+
+      return fetch(event.request).then((response) => {
+        const copy = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+        return response;
+      }).catch(() => caches.match("./index.html"));
+    }),
+  );
+});


### PR DESCRIPTION
## Summary
- add a web app manifest, icons, and service worker so Snake can be installed and launched offline
- surface install status in the UI and add standalone-friendly metadata for mobile home screen installs
- clarify the haptics messaging so installed iPhone/iPad PWAs explain the native-wrapper limitation

## Testing
- npm run build
- served locally and verified manifest.webmanifest and sw.js returned 200